### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@henriquesilverio/talk-npm-actions",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@henriquesilverio/talk-npm-actions",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "description": "Exemplo apresentado na talk \"Automatizando release de pacotes npm com GitHub Actions\"",
   "files": [
     "/src"


### PR DESCRIPTION
Version bump in `package.json` and `package-lock.json` for release [v1.1.0](https://github.com/HenriqueSilverio/talk-npm-actions/releases/tag/v1.1.0)